### PR TITLE
Event driven sensor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .vscode/
+__pycache__/
+.DS_Store
+*.code-workspace
+*.ipynb

--- a/custom_components/garo_wallbox/base.py
+++ b/custom_components/garo_wallbox/base.py
@@ -2,8 +2,12 @@ from abc import abstractmethod
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.core import callback
 from .coordinator import GaroDeviceCoordinator, GaroMeterCoordinator
 from .garo import GaroCharger, GaroMeter
+from homeassistant.const import CONF_TYPE
+from .const import EVENT_NAME, EVENT_TYPE_DATA_UPDATED
+
 
 class GaroEntity(CoordinatorEntity[GaroDeviceCoordinator]):
     _attr_has_entity_name = True
@@ -29,6 +33,24 @@ class GaroEntity(CoordinatorEntity[GaroDeviceCoordinator]):
     @abstractmethod
     def _async_update_attrs(self) -> None:
         """Update the attributes of the entity."""
+
+    async def async_added_to_hass(self) -> None:
+        """Add event listener to update data when sensor added to hass."""
+        await super().async_added_to_hass()
+        # _LOGGER.debug(f"Sensor '{self.name}' added to Hass")
+        # Listen for event and update sensor
+        self.hass.bus.async_listen(EVENT_NAME, self.async_handle_event)
+
+    @callback
+    async def async_handle_event(self, event):
+        """Handle an event and update state."""
+        if event.data.get(CONF_TYPE) == EVENT_TYPE_DATA_UPDATED:
+            # _LOGGER.debug(f"Event captured: '{EVENT_NAME}' is of type '{EVENT_TYPE_DATA_UPDATED}'")
+            self._async_update_attrs()
+            self.async_write_ha_state()
+        else:
+            # _LOGGER.debug(f"Event ignored: '{EVENT_NAME}' is of type '{EVENT_TYPE_DATA_UPDATED}'")
+            pass
 
 class GaroMeterEntity(CoordinatorEntity[GaroMeterCoordinator]):
     _attr_has_entity_name = True

--- a/custom_components/garo_wallbox/const.py
+++ b/custom_components/garo_wallbox/const.py
@@ -21,3 +21,6 @@ COORDINATOR = "coordinator"
 COMPONENT_TYPES = ["sensor","select","number","switch"]
 
 ATTR_MODES = "modes"
+
+EVENT_NAME = "garo_wallbox_event"
+EVENT_TYPE_DATA_UPDATED = "data_updated"

--- a/custom_components/garo_wallbox/coordinator.py
+++ b/custom_components/garo_wallbox/coordinator.py
@@ -2,7 +2,7 @@ import logging
 
 from datetime import timedelta, datetime, time
 from homeassistant.core import HomeAssistant
-from homeassistant.const import CONF_NAME
+from homeassistant.const import (CONF_NAME, CONF_TYPE)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.entity import DeviceInfo
@@ -142,6 +142,10 @@ class GaroDeviceCoordinator(DataUpdateCoordinator[int]):
                         break
             if has_changed:
                 self._update_id += 1
+
+                # Trigger event to update entities
+                self.hass.bus.async_fire(const.EVENT_NAME, {CONF_TYPE: const.EVENT_TYPE_DATA_UPDATED})
+
         except BaseException as e:
             _LOGGER.error("Error fetching device data from API: %s", e, exc_info=e)
             raise UpdateFailed(f"Invalid response from API: {e}") from e

--- a/custom_components/garo_wallbox/select.py
+++ b/custom_components/garo_wallbox/select.py
@@ -97,6 +97,7 @@ class GaroSelectEntity(GaroEntity, SelectEntity):
     
     async def async_select_option(self, option: str) -> None:
         await self.entity_description.set_option(option)
+        await self.coordinator._fetch_device_data()
         self._attr_current_option = option
         self.async_write_ha_state()
 


### PR DESCRIPTION
### Issue
When the select option _Garo Wallbox_ is changed to e.g. `Not Available for Charging` from HomeAssistant it can take up to 30 seconds until the sensor (`sensor.garo_wallbox`) is updated. 

<img width="498" alt="image" src="https://github.com/user-attachments/assets/f72598e1-7803-45e6-be9b-e957d7cfb2a4">

### Solution
This code fix ensures that the status (and all other sensors' values) are updated immediately when the option is changed in HomeAssistant.
