### PR TITLE
feat: add firmware updates, restart button, RFID switch, and LB fuse controls

### DIFF
--- a/custom_components/garo_wallbox/button.py
+++ b/custom_components/garo_wallbox/button.py
@@ -1,0 +1,37 @@
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription, ButtonDeviceClass
+
+from .coordinator import GaroDeviceCoordinator
+from .base import GaroEntity
+from . import GaroConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass: HomeAssistant, entry: GaroConfigEntry, async_add_entities):
+    """Set up using config_entry."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities([GaroRestartButton(coordinator, entry)])
+
+
+class GaroRestartButton(GaroEntity, ButtonEntity):
+    """Restarts the wallbox (warm reset)."""
+
+    _attr_device_class = ButtonDeviceClass.RESTART
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: GaroDeviceCoordinator, entry) -> None:
+        self.entity_description = ButtonEntityDescription(
+            key="restart",
+            translation_key="restart",
+            name="Restart",
+        )
+        super().__init__(coordinator, entry, self.entity_description.key)
+
+    def _async_update_attrs(self) -> None:
+        """Buttons have no state to update."""
+
+    async def async_press(self) -> None:
+        """Restart the wallbox."""
+        await self.coordinator.async_restart()

--- a/custom_components/garo_wallbox/const.py
+++ b/custom_components/garo_wallbox/const.py
@@ -18,6 +18,6 @@ SERVICE_SET_SCHEDULE = "set_schedule"
 SERVICE_REMOVE_SCHEDULE = "remove_schedule"
 
 COORDINATOR = "coordinator"
-COMPONENT_TYPES = ["sensor","select","number","switch"]
+COMPONENT_TYPES = ["sensor","select","number","switch","button","update"]
 
 ATTR_MODES = "modes"

--- a/custom_components/garo_wallbox/coordinator.py
+++ b/custom_components/garo_wallbox/coordinator.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.storage import Store
 
-from .garo import ApiClient, GaroConfig, GaroStatus, GaroCharger, GaroMeter, GaroSchema
+from .garo import ApiClient, GaroConfig, GaroStatus, GaroCharger, GaroMeter, GaroSchema, GaroLBConfig
 from .garo.const import CableLockMode, PRODUCT_MAP, GaroProductInfo, Mode as GaroMode
 from . import const
 
@@ -146,6 +146,13 @@ class GaroDeviceCoordinator(DataUpdateCoordinator[int]):
         await self._api_client.async_set_current_limit(limit)
         await self.async_request_refresh()
 
+    async def async_set_rfid_mode(self, enabled: bool):
+        await self._api_client.async_set_rfid_mode(enabled)
+        self._config = await self._api_client.async_get_configuration()
+        self.async_update_listeners()
+
+    async def async_restart(self):
+        await self._api_client.async_restart()
 
     async def _fetch_device_data(self)->int:
         try:
@@ -180,6 +187,7 @@ class GaroMeterCoordinator(DataUpdateCoordinator[int]):
         self._external_meter: GaroMeter | None = None
         self._central100_meter: GaroMeter | None = None
         self._central101_meter: GaroMeter | None = None
+        self._lb_config: GaroLBConfig | None = None
         self._store = Store(hass, version=1, key="garo_meter")
         self._stored_data: dict|None = None
         
@@ -212,6 +220,15 @@ class GaroMeterCoordinator(DataUpdateCoordinator[int]):
             raise ValueError("Central 101 meter not initialized")
         return self._central101_meter
     
+    @property
+    def has_lb_config(self) -> bool:
+        return self._lb_config is not None
+    @property
+    def lb_config(self)->GaroLBConfig:
+        if not self._lb_config:
+            raise ValueError("Load balancing config not initialized")
+        return self._lb_config
+
     @property
     def calculate_power(self)->bool:
         if self._stored_data is None:
@@ -252,6 +269,13 @@ class GaroMeterCoordinator(DataUpdateCoordinator[int]):
         await self._store.async_save(self._stored_data)
         self.async_update_listeners()
 
+    async def async_set_lb_fuse(self, fuse: int):
+        await self._api_client.async_set_lb_fuse(fuse)
+        await self.async_request_refresh()
+
+    async def async_set_lb_fuse101(self, fuse: int):
+        await self._api_client.async_set_lb_fuse101(fuse)
+        await self.async_request_refresh()
 
     async def _fetch_device_data(self)->int:
         try:
@@ -271,7 +295,11 @@ class GaroMeterCoordinator(DataUpdateCoordinator[int]):
                 self._central101_meter = await self._api_client.async_get_central101_meter(self._central101_meter)
                 if self._central101_meter.has_changed:
                     has_changed = True
-            
+            if self._config.group_load_balanced or self._config.group_load_balanced101:
+                self._lb_config = await self._api_client.async_get_lb_config(self._lb_config)
+                if self._lb_config.has_changed:
+                    has_changed = True
+
             if has_changed:
                 self._update_id += 1
         except Exception as e:

--- a/custom_components/garo_wallbox/garo/__init__.py
+++ b/custom_components/garo_wallbox/garo/__init__.py
@@ -4,3 +4,4 @@ from .apiclient import ApiClient
 from .garoconfig import GaroConfig
 from .garometer import GaroMeter
 from .garoschema import GaroSchema
+from .garolbconfig import GaroLBConfig

--- a/custom_components/garo_wallbox/garo/apiclient.py
+++ b/custom_components/garo_wallbox/garo/apiclient.py
@@ -8,6 +8,7 @@ from .garoconfig import GaroConfig
 from .garocharger import GaroCharger
 from .garometer import GaroMeter
 from .garoschema import GaroSchema
+from .garolbconfig import GaroLBConfig
 from . import const
 
 _LOGGER = logging.getLogger(__name__)
@@ -145,7 +146,49 @@ class ApiClient:
             await response.text()
             return
         raise ValueError('Slave with serial number {} not found'.format(serial_number))
-        
+
+    async def async_get_lb_config(self, lb_config: GaroLBConfig | None = None) -> GaroLBConfig:
+        response = await self._async_get('lbconfig/false')
+        data = await response.json()
+        if lb_config is None:
+            lb_config = GaroLBConfig(data)
+        else:
+            lb_config.load(data)
+        return lb_config
+
+    async def async_set_lb_fuse(self, fuse: int):
+        response = await self._async_get('lbconfig/false', True)
+        response_json = await response.json()
+        response_json['loadBalancingFuse'] = fuse
+        response = await self._async_post(self._get_url('lbconfig'), data=response_json)
+        await response.text()
+
+    async def async_set_lb_fuse101(self, fuse: int):
+        response = await self._async_get('lbconfig/false', True)
+        response_json = await response.json()
+        response_json['loadBalancingFuse101'] = fuse
+        response = await self._async_post(self._get_url('lbconfig'), data=response_json)
+        await response.text()
+
+    async def async_set_rfid_mode(self, enabled: bool):
+        response = await self._async_post(self._get_url(f'rfidmode/{str(enabled).lower()}'))
+        await response.text()
+
+    async def async_restart(self):
+        response = await self._async_get('warmreset')
+        await response.text()
+
+    async def async_get_update_info(self) -> dict:
+        response = await self._async_get('updatecheck', True)
+        return await response.json()
+
+    async def async_install_update(self, url: str, version):
+        response = await self._client.request(
+            method='POST',
+            url=f'http://{self._host}:8080/update/UpdaterServlet',
+            data={'url': url, 'version': version})
+        await self._raise_for_status(response, 'POST', 'UpdaterServlet')
+        return await response.json()
 
     async def _async_get(self, action: str, add_tick = False):
         response = await self._client.request(method='GET', url=self._get_url(action, add_tick))

--- a/custom_components/garo_wallbox/garo/garoconfig.py
+++ b/custom_components/garo_wallbox/garo/garoconfig.py
@@ -19,6 +19,9 @@ class GaroConfig:
         self.local_load_balanced = utils.read_bool(json, 'localLoadBalanced', False)
         self.group_load_balanced = utils.read_bool(json, 'groupLoadBalanced', False)
         self.group_load_balanced101 = utils.read_bool(json, 'groupLoadBalanced101', False)
+        self.lb_version2 = utils.read_bool(json, 'lbVersion2', False)
+        self.rfid_reader_present = utils.read_bool(json, 'rfidReaderPresent', False)
+        self.rfid_mode = utils.read_value(json, 'rfidMode', 'NONE')
 
 
         slaves = utils.read_value(json, 'slaveList', [])
@@ -61,4 +64,8 @@ class GaroConfig:
     @property
     def has_load_balancer(self):
         return self.local_load_balanced or self.group_load_balanced or self.group_load_balanced101
+
+    @property
+    def rfid_enabled(self):
+        return self.rfid_mode == 'RFID_WIFI'
 

--- a/custom_components/garo_wallbox/garo/garolbconfig.py
+++ b/custom_components/garo_wallbox/garo/garolbconfig.py
@@ -1,0 +1,73 @@
+from . import utils
+
+class GaroLBConfig:
+    """Holds the main fuse/power subscription load balancing settings (lbconfig endpoint)."""
+
+    def __init__(self, json = None):
+        self._fuse = 0
+        self._power = 0
+        self._fuse101 = 0
+        self._power101 = 0
+
+        self._has_changed = False
+        self.load(json)
+
+    def load(self, json = None) -> bool:
+        self._has_changed = False
+        if not json:
+            return False
+
+        self.fuse = utils.read_value(json, 'loadBalancingFuse', self._fuse)
+        self.power = utils.read_value(json, 'loadBalancingPower', self._power)
+        self.fuse101 = utils.read_value(json, 'loadBalancingFuse101', self._fuse101)
+        self.power101 = utils.read_value(json, 'loadBalancingPower101', self._power101)
+
+        return self._has_changed
+
+    @property
+    def has_changed(self):
+        return self._has_changed
+
+    @property
+    def fuse(self):
+        """Main fuse current limit (A) for the LB Meter 100 group."""
+        return self._fuse
+    @fuse.setter
+    def fuse(self, value):
+        if self._fuse == value:
+            return
+        self._fuse = value
+        self._has_changed = True
+
+    @property
+    def power(self):
+        """Power subscription limit (kW) for the LB Meter 100 group."""
+        return self._power
+    @power.setter
+    def power(self, value):
+        if self._power == value:
+            return
+        self._power = value
+        self._has_changed = True
+
+    @property
+    def fuse101(self):
+        """Main fuse current limit (A) for the LB Meter 101 group."""
+        return self._fuse101
+    @fuse101.setter
+    def fuse101(self, value):
+        if self._fuse101 == value:
+            return
+        self._fuse101 = value
+        self._has_changed = True
+
+    @property
+    def power101(self):
+        """Power subscription limit (kW) for the LB Meter 101 group."""
+        return self._power101
+    @power101.setter
+    def power101(self, value):
+        if self._power101 == value:
+            return
+        self._power101 = value
+        self._has_changed = True

--- a/custom_components/garo_wallbox/icons.json
+++ b/custom_components/garo_wallbox/icons.json
@@ -31,6 +31,14 @@
                     "3":"mdi:google-circles-communities"
                 }
             },
+            "power_mode": {
+                "state": {
+                    "ON": "mdi:electric-switch-closed",
+                    "OFF": "mdi:electric-switch",
+                    "UNKNOWN": "mdi:help",
+                    "UNAVAILABLE": "mdi:help"
+                }
+            },
             "left_status": {
                 "state": {
                     "CHANGING": "mdi:update",

--- a/custom_components/garo_wallbox/number.py
+++ b/custom_components/garo_wallbox/number.py
@@ -77,6 +77,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: GaroConfigEntry, async_a
             add_meter_entities(meter_coordinator.central100_meter)
         if meter_coordinator.has_central101_meter:
             add_meter_entities(meter_coordinator.central101_meter)
+
+        def add_lb_fuse_entity(meter: GaroMeter, get_fuse: Callable[[], int], set_fuse: Callable[[int], Awaitable]):
+            max_fuse = 2500 if configuration.lb_version2 else 63
+            entities.append(GaroMeterNumberEntity(meter_coordinator, entry, GaroMeterNumberEntityDescription(
+                key="lb_main_fuse",
+                translation_key="lb_main_fuse",
+                name="Main Fuse",
+                icon="mdi:gauge-full",
+                native_max_value=max_fuse,
+                native_min_value=16,
+                native_step=1,
+                native_unit_of_measurement="A",
+                mode=NumberMode.BOX,
+                get_value=lambda status: get_fuse(),
+                set_value=set_fuse,
+                is_available=lambda: True,
+            ), meter))
+        if meter_coordinator.has_lb_config:
+            if meter_coordinator.has_central100_meter:
+                add_lb_fuse_entity(
+                    meter_coordinator.central100_meter,
+                    lambda: meter_coordinator.lb_config.fuse,
+                    meter_coordinator.async_set_lb_fuse)
+            if meter_coordinator.has_central101_meter:
+                add_lb_fuse_entity(
+                    meter_coordinator.central101_meter,
+                    lambda: meter_coordinator.lb_config.fuse101,
+                    meter_coordinator.async_set_lb_fuse101)
     async_add_entities(entities)
 
 

--- a/custom_components/garo_wallbox/sensor.py
+++ b/custom_components/garo_wallbox/sensor.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature, UnitOfElectricCurrent, UnitOfEnergy, UnitOfPower, UnitOfTime
+from homeassistant.const import UnitOfTemperature, UnitOfElectricCurrent, UnitOfEnergy, UnitOfPower, UnitOfTime, EntityCategory
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
@@ -156,6 +156,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: GaroConfigEntry, async_a
                 state_class=SensorStateClass.MEASUREMENT,
                 native_unit_of_measurement=UnitOfTemperature.CELSIUS,
                 get_state=lambda status: status.current_temperature,
+            ),
+            GaroSensorEntityDescription(
+                key="power_mode",
+                translation_key="power_mode",
+                name="Power Mode",
+                icon="mdi:electric-switch",
+                options=[opt.value for opt in const.PowerMode],
+                device_class=SensorDeviceClass.ENUM,
+                state_class=None,
+                get_state=lambda status: status.power_mode.value,
+            ),
+            GaroSensorEntityDescription(
+                key="charge_status",
+                translation_key="charge_status",
+                name="Charge Status Code",
+                icon="mdi:code-tags",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                entity_registry_enabled_default=False,
+                state_class=None,
+                get_state=lambda status: hex(status.charge_status),
             )
         ]]
     if (coordinator.config.has_twin):
@@ -239,6 +259,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: GaroConfigEntry, async_a
                 get_state=lambda status: status.main_charger.accumulated_energy / 1000 if status.main_charger.accumulated_energy else None,
             ),
             GaroSensorEntityDescription(
+                key="left_charge_status",
+                translation_key="left_charge_status",
+                name="Left Charge Status Code",
+                icon="mdi:code-tags",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                entity_registry_enabled_default=False,
+                state_class=None,
+                get_state=lambda status: hex(status.main_charger.charge_status),
+            ),
+            GaroSensorEntityDescription(
                 key="right_status",
                 translation_key="right_status",
                 name="Right Status",
@@ -315,6 +345,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: GaroConfigEntry, async_a
                 state_class=SensorStateClass.TOTAL_INCREASING,
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 get_state=lambda status: status.twin_charger.accumulated_energy / 1000 if status.twin_charger.accumulated_energy else None,
+            ),
+            GaroSensorEntityDescription(
+                key="right_charge_status",
+                translation_key="right_charge_status",
+                name="Right Charge Status Code",
+                icon="mdi:code-tags",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                entity_registry_enabled_default=False,
+                state_class=None,
+                get_state=lambda status: hex(status.twin_charger.charge_status),
             ),
         ])
     entities.append(
@@ -412,6 +452,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: GaroConfigEntry, async_a
                 state_class=SensorStateClass.TOTAL_INCREASING,
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 get_state=lambda charger: charger.accumulated_energy / 1000 if charger.accumulated_energy else None,
+            ),
+            GaroChargerSensorEntityDescription(
+                key="charge_status",
+                translation_key="charge_status",
+                name="Charge Status Code",
+                icon="mdi:code-tags",
+                entity_category=EntityCategory.DIAGNOSTIC,
+                entity_registry_enabled_default=False,
+                state_class=None,
+                get_state=lambda charger: hex(charger.charge_status),
             )
         ])
     entities.append(GaroScheduleSensorEntity(coordinator, entry))

--- a/custom_components/garo_wallbox/strings.json
+++ b/custom_components/garo_wallbox/strings.json
@@ -110,6 +110,18 @@
       "current_temperature": {
         "name": "Temperature"
       },
+      "power_mode": {
+        "name": "Power Mode",
+        "state": {
+          "ON": "Power on",
+          "OFF": "Power off",
+          "UNKNOWN": "Unknown",
+          "UNAVAILABLE": "Unavailable"
+        }
+      },
+      "charge_status": {
+        "name": "Charge Status Code"
+      },
       "left_status": {
         "name": "Left Outlet",
         "state": {
@@ -162,6 +174,9 @@
       "left_acc_energy": {
         "name": "Left Total Energy"
       },
+      "left_charge_status": {
+        "name": "Left Charge Status Code"
+      },
       "right_status": {
         "name": "Right Outlet",
         "state": {
@@ -213,6 +228,9 @@
       },
       "right_acc_energy": {
         "name": "Right Total Energy"
+      },
+      "right_charge_status": {
+        "name": "Right Charge Status Code"
       }
     },
     "select": {
@@ -251,11 +269,27 @@
     "number": {
       "current_limit": {
         "name": "Current Limit"
+      },
+      "lb_main_fuse": {
+        "name": "Main Fuse"
       }
     },
     "switch": {
       "charge_limit": {
         "name": "Charge Limiter"
+      },
+      "rfid_enabled": {
+        "name": "RFID Authorization"
+      }
+    },
+    "button": {
+      "restart": {
+        "name": "Restart"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
       }
     }
   }

--- a/custom_components/garo_wallbox/switch.py
+++ b/custom_components/garo_wallbox/switch.py
@@ -35,6 +35,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: GaroConfigEntry, async_a
                 get_state=lambda: coordinator.config.charge_limit_enabled,
             ),
         ]]
+    if coordinator.config.rfid_reader_present:
+        entities.append(GaroSwitchEntity(coordinator, entry, GaroSwitchEntityDescription(
+            key="rfid_enabled",
+            translation_key="rfid_enabled",
+            name="RFID Authorization",
+            icon="mdi:card-account-details-outline",
+            on_func=lambda: coordinator.async_set_rfid_mode(True),
+            off_func=lambda: coordinator.async_set_rfid_mode(False),
+            get_state=lambda: coordinator.config.rfid_enabled,
+        )))
     if entry.runtime_data.meter_coordinator:
         meter_coordinator = entry.runtime_data.meter_coordinator
         def add_meter_entities(meter: GaroMeter):

--- a/custom_components/garo_wallbox/translations/en.json
+++ b/custom_components/garo_wallbox/translations/en.json
@@ -110,6 +110,18 @@
       "current_temperature": {
         "name": "Temperature"
       },
+      "power_mode": {
+        "name": "Power Mode",
+        "state": {
+          "ON": "Power on",
+          "OFF": "Power off",
+          "UNKNOWN": "Unknown",
+          "UNAVAILABLE": "Unavailable"
+        }
+      },
+      "charge_status": {
+        "name": "Charge Status Code"
+      },
       "left_status": {
         "name": "Left Outlet",
         "state": {
@@ -162,6 +174,9 @@
       "left_acc_energy": {
         "name": "Left Total Energy"
       },
+      "left_charge_status": {
+        "name": "Left Charge Status Code"
+      },
       "right_status": {
         "name": "Right Outlet",
         "state": {
@@ -213,6 +228,9 @@
       },
       "right_acc_energy": {
         "name": "Right Total Energy"
+      },
+      "right_charge_status": {
+        "name": "Right Charge Status Code"
       }
     },
     "select": {
@@ -251,11 +269,27 @@
     "number": {
       "current_limit": {
         "name": "Current Limit"
+      },
+      "lb_main_fuse": {
+        "name": "Main Fuse"
       }
     },
     "switch": {
       "charge_limit": {
         "name": "Charge Limiter"
+      },
+      "rfid_enabled": {
+        "name": "RFID Authorization"
+      }
+    },
+    "button": {
+      "restart": {
+        "name": "Restart"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
       }
     }
   }

--- a/custom_components/garo_wallbox/update.py
+++ b/custom_components/garo_wallbox/update.py
@@ -1,0 +1,69 @@
+from datetime import timedelta
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.components.update import (
+    UpdateEntity,
+    UpdateEntityDescription,
+    UpdateDeviceClass,
+    UpdateEntityFeature,
+)
+
+from .coordinator import GaroDeviceCoordinator
+from . import GaroConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+# The wallbox checks its cloud service for new firmware; there is no need to poll this often.
+SCAN_INTERVAL = timedelta(hours=12)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: GaroConfigEntry, async_add_entities):
+    """Set up using config_entry."""
+    coordinator = entry.runtime_data.coordinator
+    async_add_entities([GaroUpdateEntity(coordinator, entry)], True)
+
+
+class GaroUpdateEntity(UpdateEntity):
+    """Reports and installs available Garo Wallbox firmware updates."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = UpdateEntityFeature.INSTALL
+
+    def __init__(self, coordinator: GaroDeviceCoordinator, entry) -> None:
+        self.config_entry = entry
+        self._coordinator = coordinator
+        self.entity_description = UpdateEntityDescription(
+            key="firmware",
+            translation_key="firmware",
+            name="Firmware",
+        )
+        self._attr_unique_id = f"{coordinator.device_id}-firmware"
+        self._attr_device_info = coordinator.device_info
+        self._attr_installed_version = str(coordinator.config.software_version)
+        self._latest_url: str | None = None
+
+    async def async_update(self) -> None:
+        """Check the wallbox's cloud service for a newer firmware version."""
+        self._attr_installed_version = str(self._coordinator.config.software_version)
+        try:
+            data = await self._coordinator.api_client.async_get_update_info()
+        except Exception as e:
+            _LOGGER.debug("Failed to check for firmware update: %s", e)
+            return
+        latest_version = int(data.get('latest_version', -1))
+        if latest_version < 0:
+            # -1: chargebox has no internet connectivity, -2: chargebox clock is out of sync
+            self._latest_url = None
+            self._attr_latest_version = self._attr_installed_version
+            return
+        self._latest_url = data.get('url')
+        self._attr_latest_version = str(latest_version)
+
+    async def async_install(self, version: str | None, backup: bool, **kwargs) -> None:
+        """Trigger the wallbox to download and install the new firmware."""
+        if not self._latest_url:
+            raise HomeAssistantError("No firmware update package is available")
+        await self._coordinator.api_client.async_install_update(self._latest_url, self._attr_latest_version)


### PR DESCRIPTION
- Add update entity to check and install wallbox firmware via the wallbox's cloud update check (updatecheck/UpdaterServlet API)
- Add disabled-by-default restart button (warm reset)
- Add RFID authorization switch for wallboxes with an RFID reader, backed by new rfidMode/rfidReaderPresent config fields
- Add load balancing main fuse number entities (Central 100/101) with lb_version2-aware max, backed by new lbconfig API and GaroLBConfig
- Add power mode enum sensor
- Add diagnostic charge status code sensors (disabled by default)